### PR TITLE
feat: improve UI layout and add build-time image info

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,9 @@ builds:
   - env:
       - CGO_ENABLED=0
     binary: "{{ .ProjectName }}"
+    ldflags:
+      - -s -w
+      - -X github.com/sunggun-yu/hello-app/internal/config.buildImage={{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Version }}
     goos:
       - linux
       - darwin

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The application uses the following environment variables:
 
 - `COLOR`: Used as the accent color for the root (`/`) endpoint UI (header bar background). Accepts any CSS color value (e.g., `#ef476f`, `green`). Defaults to `#7cc423`.
 
+The container image reference (e.g., `ghcr.io/sunggun-yu/hello-app:0.11.3`) is embedded into the binary at build time via `ldflags` and displayed in the UI footer. This is set automatically by GoReleaser during the release process.
+
 ### GRPC Endpoints
 
 #### Describe the HelloService

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,10 +12,13 @@ const (
 	PRIMARY_GRPC_PORT_ENV  = "GRPC_PORT"
 )
 
+// buildImage is set at build time via ldflags
+var buildImage string
+
 var (
-	service  = os.Getenv("SERVICE")
-	version  = os.Getenv("VERSION")
-	color    = os.Getenv("COLOR")
+	service = os.Getenv("SERVICE")
+	version = os.Getenv("VERSION")
+	color   = os.Getenv("COLOR")
 	webPort1 = func() string {
 		port := os.Getenv(PRIMARY_WEB_PORT_ENV)
 		if port == "" {
@@ -41,6 +44,7 @@ var (
 
 type Config struct {
 	Color   string `json:"color,omitempty"`
+	Image   string `json:"image,omitempty"`
 	Port    string `json:"port,omitempty"`
 	Service string `json:"service,omitempty"`
 	Version string `json:"version,omitempty"`
@@ -49,6 +53,7 @@ type Config struct {
 func WebConfig1() *Config {
 	cfg := &Config{
 		Color:   color,
+		Image:   buildImage,
 		Port:    webPort1,
 		Service: service,
 		Version: version,

--- a/internal/routers/handlers.go
+++ b/internal/routers/handlers.go
@@ -17,6 +17,7 @@ func indexHandler(config *config.Config) func(*gin.Context) {
 		data := helloService.Index(config)
 		c.HTML(http.StatusOK, "index.html.tmpl", gin.H{
 			"color":         data.Color,
+			"image":         config.Image,
 			"service":       data.Service,
 			"version":       data.Version,
 			"instance":      data.Instance,

--- a/templates/index.html.tmpl
+++ b/templates/index.html.tmpl
@@ -22,6 +22,9 @@
             background: var(--bg);
             color: var(--text);
             line-height: 1.5;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
         }
         .header {
             background: var(--accent);
@@ -40,19 +43,29 @@
             font-size: .85rem;
         }
         .container {
-            max-width: 960px;
+            max-width: 1400px;
             margin: 2rem auto;
             padding: 0 1rem;
             display: flex;
             gap: 1.5rem;
             flex-wrap: wrap;
+            flex: 1;
+            align-items: flex-start;
         }
         .card {
             background: var(--card-bg);
             border-radius: 8px;
             box-shadow: 0 1px 3px rgba(0,0,0,.08);
             overflow: hidden;
-            flex: 1 1 400px;
+        }
+        .card-info {
+            width: 35%;
+            flex-shrink: 0;
+        }
+        .card-headers {
+            width: 63%;
+            flex-grow: 1;
+            min-width: 0;
         }
         .card-title {
             padding: .75rem 1.25rem;
@@ -80,9 +93,35 @@
         tbody tr:nth-child(even) { background: #f9fafb; }
         td:first-child { font-weight: 500; white-space: nowrap; }
         td:last-child { font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; font-size: .8rem; word-break: break-all; }
+        .footer {
+            padding: .75rem 2rem;
+            text-align: center;
+            font-size: .75rem;
+            color: var(--text-muted);
+            border-top: 1px solid var(--border);
+        }
+        .footer a {
+            color: var(--text-muted);
+            text-decoration: none;
+        }
+        .footer a:hover { text-decoration: underline; }
+        .footer svg {
+            width: 14px;
+            height: 14px;
+            vertical-align: -2px;
+            fill: var(--text-muted);
+            margin-right: 4px;
+        }
+        .footer .image-tag {
+            font-family: "SF Mono", SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+            background: #f0f0f0;
+            padding: .1rem .4rem;
+            border-radius: 4px;
+            font-size: .7rem;
+        }
         @media (max-width: 768px) {
             .container { flex-direction: column; }
-            .card { flex-basis: auto; }
+            .card-info, .card-headers { width: 100%; }
             .header { flex-direction: column; gap: .5rem; text-align: center; }
         }
     </style>
@@ -93,7 +132,7 @@
         <span class="badge">{{ $version }}</span>
     </div>
     <div class="container">
-        <div class="card">
+        <div class="card card-info">
             <div class="card-title">Service Info</div>
             <div class="info-row"><span class="info-label">Instance</span><span class="info-value">{{ .instance }}</span></div>
             <div class="info-row"><span class="info-label">Host</span><span class="info-value">{{ .host }}</span></div>
@@ -104,7 +143,7 @@
             <div class="info-row"><span class="info-label">Remote Address</span><span class="info-value">{{ .remoteAddr }}</span></div>
             <div class="info-row"><span class="info-label">Timestamp</span><span class="info-value">{{ .timestamp }}</span></div>
         </div>
-        <div class="card">
+        <div class="card card-headers">
             <div class="card-title">Request Headers</div>
             <table>
                 <thead>
@@ -117,6 +156,14 @@
                 </tbody>
             </table>
         </div>
+    </div>
+    <div class="footer">
+        <a href="https://github.com/sunggun-yu/hello-app" target="_blank" rel="noopener">
+            <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>sunggun-yu/hello-app</a>
+        {{ if .image }}
+        <span style="margin: 0 .5rem;">|</span>
+        <span class="image-tag">{{ .image }}</span>
+        {{ end }}
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add footer with GitHub repo link and container image reference (injected at build time via `ldflags`, not env var — can't be forgotten)
- Change card layout to percentage-based: 35% service info (fixed), 63% request headers (flexible)
- Request headers card now expands to fill available space on wider viewports

## Changes
- `.goreleaser.yaml` — added `ldflags` to inject `buildImage` at build time
- `internal/config/config.go` — added `buildImage` var and `Image` field
- `internal/routers/handlers.go` — pass image to template
- `templates/index.html.tmpl` — footer with GitHub icon + image tag, %-based card layout
- `README.md` — documented build-time image injection

## Test plan
- [x] Built with `-ldflags -X ...buildImage=ghcr.io/sunggun-yu/hello-app:0.11.3-test`
- [x] Deployed to minikube, verified footer shows correct image tag
- [x] Verified image tag is empty when not built with ldflags (graceful fallback)
- [x] Verified responsive layout stacks cards on narrow viewports